### PR TITLE
-default config file name fix.

### DIFF
--- a/guncontrol.sh
+++ b/guncontrol.sh
@@ -39,7 +39,7 @@ if [[ -n "$CMD" ]]; then
   if [[ "$CMD" == "start" ]]; then
     for f in $FILES
     do
-      NAME="${f%-*}"
+      NAME=$(echo $f| cut -d'-' -f 2)
       echo -e "${WHITE}""• Checking if ${YELLOW}$NAME ${WHITE}is running...\t${RESET}\c"
       if ! screen -list | grep -qw "$NAME"; then
         echo -e "${RED}${BOLD}- NO!${RESET}\c"

--- a/guncontrol.sh
+++ b/guncontrol.sh
@@ -68,7 +68,7 @@ if [[ -n "$CMD" ]]; then
   if [[ "$CMD" == "stop" ]]; then
     for f in $FILES
     do
-      NAME="${f%-*}"
+      NAME=$(echo $f| cut -d'-' -f 2)
       echo -e "${WHITE}• Checking if ${YELLOW}$NAME ${WHITE}is running...\t${RESET}\c"
       if ! screen -list | grep -q "$NAME"; then
         echo -e "${GREEN}${BOLD}【 NO! 】\t${RESET}\c"


### PR DESCRIPTION
default config file names starts with "poloniex" or "kraken", script doesn't cut beggining text.