### PR TITLE
Fix problem with similar named pairs

### DIFF
--- a/guncontrol.sh
+++ b/guncontrol.sh
@@ -48,7 +48,7 @@ if [[ -n "$CMD" ]]; then
       NAME=${NAME1#"poloniex-"}
 
       echo -e "${WHITE}"" • Checking ${YELLOW}$NAME${WHITE}...  ${RESET}\c"
-      if ! screen -list | grep -q "$NAME"; then
+      if ! screen -list | grep -wo "$NAME"; then
         echo -e "${BLUE}""\t\t\tSTOPPED!\n   Starting \c""${RESET}"
         screen -dmS "$NAME" "${BOTFOLDER}"/gunbot "$NAME" poloniex && sleep 1
         echo -n "${BLUE}...1 ${RESET}" && sleep 1


### PR DESCRIPTION
`grep -wo ` will only match on words, so `grep -wo "BTC_STR"` will match `BTC_STR` but not `BTC_STRAT`